### PR TITLE
Allow user to change status manually

### DIFF
--- a/lib/capistrano/tasks/github.rake
+++ b/lib/capistrano/tasks/github.rake
@@ -70,7 +70,7 @@ namespace :github do
     end
   end
 
-  print_deployment = -> d { puts "Deployment (#{d.last_state}): #{d.created_at} #{d.ref}@#{d.sha} to #{d.environment} by @#{d.creator_login}" }
+  print_deployment = -> d { puts "Deployment##{d.id} (#{d.last_state}): #{d.created_at} #{d.ref}@#{d.sha} to #{d.environment} by @#{d.creator_login}" }
   print_status = -> s { puts "\t#{s.created_at} state: #{s.state}" }
 
   desc 'List Github deployments'

--- a/lib/capistrano/tasks/github.rake
+++ b/lib/capistrano/tasks/github.rake
@@ -36,7 +36,7 @@ namespace :github do
   namespace :deployment do
     desc 'Create new deployment'
     task :create do
-      next if fetch(:github_deployment_skip)
+      next if fetch(:github_deployment_skip) || fetch(:current_github_deployment)
 
       gh = fetch(:github_deployment_api)
       payload = fetch(:github_deployment_payload)


### PR DESCRIPTION
Hi,

This change allows user to

- retrieve deployment ID from print output
- manually update deployment status

with configuration

```rb
# config/deploy.rb
set :current_github_deployment, ENV['GITHUB_DEPLOYMENT']
```

retrieve ID from listing

```
$ cap production github:deployments

Deployment#12345 (unknown): 2017-03-16 19:26:25 UTC master@abc... to production by @ngs
```

then run

```sh
$ GITHUB_DEPLOYMENT=12345 cap production github:deployment:error
```