### PR TITLE
Update octokit dependency to >= 4

### DIFF
--- a/capistrano-github.gemspec
+++ b/capistrano-github.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", "~> 3.1"
-  spec.add_dependency "octokit", ">= 3.0", "< 4.0"
+  spec.add_dependency "octokit", ">= 4.0", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Hi there -- thanks for maintaining this.  I recently tried to add it to a Rails 6 app but ran into issues with the `addressable` gem dependency (via the `octokit` and `sawyer` gems).  I bumped `octkit` to 4.x and things work well now (both the specs and actually deploying).